### PR TITLE
Update antlr version to the latest 4.7.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject lein-antlr "0.3.0"
+(defproject lein-antlr "0.4.0-SNAPSHOT"
   :description "Generate source code from ANTLR grammars in Leiningen."
-  :dependencies [[org.antlr/antlr4 "4.5"]]
+  :dependencies [[org.antlr/antlr4 "4.7.1"]]
   :profile {:dev {:dependencies [[org.clojure/clojure "1.4.0"]]}}
   :url "http://github.com/alexhall/lein-antlr"
   :eval-in-leiningen true


### PR DESCRIPTION
Check [antlr4 releases](https://github.com/antlr/antlr4/releases) - especially escape sequences which now produce warnings (e.g. https://github.com/antlr/antlr4/issues/1717).